### PR TITLE
Feature/back end/infra

### DIFF
--- a/back-end/src/main/java/com/melodify/infra/exception/CustomException.java
+++ b/back-end/src/main/java/com/melodify/infra/exception/CustomException.java
@@ -6,28 +6,28 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.web.server.ResponseStatusException;
 
 @Getter
-public class CustomErrorException extends ResponseStatusException {
+public class CustomException extends ResponseStatusException {
     private HttpStatusCode statusCode;
     private String message;
     private Throwable cause;
 
-    public CustomErrorException(String message) {
+    public CustomException(String message) {
         super(HttpStatus.INTERNAL_SERVER_ERROR);
         this.message = message;
     }
 
-    public CustomErrorException(HttpStatusCode statusCode) {
+    public CustomException(HttpStatusCode statusCode) {
         super(statusCode);
         this.statusCode = statusCode;
     }
 
-    public CustomErrorException(HttpStatusCode statusCode, String message) {
+    public CustomException(HttpStatusCode statusCode, String message) {
         super(statusCode, message);
         this.statusCode = statusCode;
         this.message = message;
     }
 
-    public CustomErrorException(HttpStatusCode statusCode, String message, Throwable cause) {
+    public CustomException(HttpStatusCode statusCode, String message, Throwable cause) {
         super(statusCode, message, cause);
         this.statusCode = statusCode;
         this.message = message;

--- a/back-end/src/main/java/com/melodify/infra/exception/ErrorHandler.java
+++ b/back-end/src/main/java/com/melodify/infra/exception/ErrorHandler.java
@@ -17,24 +17,23 @@ public class ErrorHandler {
         HttpStatusCode status = HttpStatus.INTERNAL_SERVER_ERROR;
         String message = e.getMessage();
         logError(status, message, "Exception");
-        return ResponseEntity.internalServerError().body(new CustomErrorResponse(status, "Erro inesperado: "+message));
+        return ResponseEntity.internalServerError().body(new ExceptionResponse(status, "Erro inesperado: "+message));
     }
-
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<?> handler(ResponseStatusException e) {
         HttpStatusCode status = e.getStatusCode();
         String message = e.getMessage();
         logError(status, message, "ResponseStatusException");
-        return ResponseEntity.status(status).body(new CustomErrorResponse(status, message));
+        return ResponseEntity.status(status).body(new ExceptionResponse(status, message));
     }
 
-    @ExceptionHandler(CustomErrorException.class)
-    public ResponseEntity<?> handler(CustomErrorException e) {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> handler(CustomException e) {
         HttpStatusCode status = e.getStatusCode();
         String message = e.getMessage();
         logError(status, message, "intencional");
-        return ResponseEntity.status(status).body(new CustomErrorResponse(status, message));
+        return ResponseEntity.status(status).body(new ExceptionResponse(status, message));
     }
 
     public void logError(HttpStatusCode status, String message, String type) {

--- a/back-end/src/main/java/com/melodify/infra/exception/ExceptionResponse.java
+++ b/back-end/src/main/java/com/melodify/infra/exception/ExceptionResponse.java
@@ -10,12 +10,6 @@ public class ExceptionResponse {
     private final HttpStatusCode erro;
     private final String mensagem;
 
-    public ExceptionResponse(@NonNull HttpStatusCode error) {
-        this.status = error.value();
-        this.erro = error;
-        this.mensagem = "Um erro inesperado ocorreu";
-    }
-
     public ExceptionResponse(@NonNull HttpStatusCode error, @NonNull String message) {
         this.status = error.value();
         this.erro = error;

--- a/back-end/src/main/java/com/melodify/infra/exception/ExceptionResponse.java
+++ b/back-end/src/main/java/com/melodify/infra/exception/ExceptionResponse.java
@@ -5,18 +5,18 @@ import lombok.NonNull;
 import org.springframework.http.HttpStatusCode;
 
 @Getter
-public class CustomErrorResponse {
+public class ExceptionResponse {
     private final int status;
     private final HttpStatusCode erro;
     private final String mensagem;
 
-    public CustomErrorResponse(@NonNull HttpStatusCode error) {
+    public ExceptionResponse(@NonNull HttpStatusCode error) {
         this.status = error.value();
         this.erro = error;
         this.mensagem = "Um erro inesperado ocorreu";
     }
 
-    public CustomErrorResponse(@NonNull HttpStatusCode error, @NonNull String message) {
+    public ExceptionResponse(@NonNull HttpStatusCode error, @NonNull String message) {
         this.status = error.value();
         this.erro = error;
         this.mensagem = message;


### PR DESCRIPTION
Small adjusts on exceptions:

- Renamed `CustomErrorException` to `CustomException`;
- Renamed `CustomErrorResponse` to `ExceptionResponse`;

- Removed constructor from `ExceptionResponse`:
  - Constructor with only `HttpStatusCode error` as parameter was removed due to having errors without messages being extremely not recommended.